### PR TITLE
Allow JS clients to access pool contents

### DIFF
--- a/serving.py
+++ b/serving.py
@@ -999,7 +999,7 @@ class WebsocketServer (threading.Thread):
         ret = self.shared_base_http_handler(path)
         if ret is None:
             return None
-        headers = [("Content-Type", "application/octet-stream"), ("Content-Length", str(len(ret)))]
+        headers = [("Content-Type", "application/octet-stream"), ("Content-Length", str(len(ret))), ("Access-Control-Allow-Origin", "*")]
         return http.HTTPStatus.OK, headers, ret
 
     def new_base_htpp_handler(self, connection, request):
@@ -1009,6 +1009,7 @@ class WebsocketServer (threading.Thread):
         headers = websockets.datastructures.Headers()
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Length"] = str(len(ret))
+        headers["Access-Control-Allow-Origin"] = "*"
         return websockets.http11.Response(http.HTTPStatus.OK, "OK", headers, ret)
 
     def get_base_htpp_handler(self):


### PR DESCRIPTION
Allow JS clients to access pool contents. Without allowing other origins JS clients from a page loaded under a different URL (such as pokemon.gblink.io) are unable to access the pool files.